### PR TITLE
Fix rounding behavior for negative numbers starting with -0.xx

### DIFF
--- a/src/AbntNbr5891.php
+++ b/src/AbntNbr5891.php
@@ -108,6 +108,10 @@ class AbntNbr5891
                 }
 
                 $final = ((float)(($intPart + $sumInt) . '.' . ($decimals)));
+
+                if ($intPart === '-0') {
+                    $final *= -1;
+                }
             }
         }
 

--- a/tests/AbntNbr5891Test.php
+++ b/tests/AbntNbr5891Test.php
@@ -43,6 +43,7 @@ class AbntNbr5891Test extends \PHPUnit\Framework\TestCase
             [0.046, 0.05],
             [0.026, 0.03],
             [0.2345645, 0.23],
+            [-0.775, -0.78]
         );
 
         foreach ($amounts as $index => $amountInfo) {


### PR DESCRIPTION
## Fix rounding behavior for negative numbers starting with -0.xx

### Problem
When rounding negative decimal numbers starting with -0.xx, the function was incorrectly converting the result to a positive value instead of preserving the negative sign.

**Example of incorrect behavior:**
- Input: `-0.775`
- Expected output: `-0.78`
- Actual output: `0.78` ❌

### Solution
Fixed the rounding logic to properly maintain the negative sign for numbers starting with -0.xx by adding a check for the integer part being '-0'.

**After fix:**
- Input: `-0.775`
- Output: `-0.78` ✅

### Changes
- Added condition to check if `$intPart === '-0'` in the `round()` function
- When this condition is met, the final result is multiplied by `-1` to preserve the negative sign
- Added corresponding test case `[-0.775, -0.78]` to verify the fix

### Testing
- Verified that negative decimals starting with -0.xx now round correctly while preserving the sign
- Confirmed that existing functionality for other number ranges remains unchanged
- Added unit test to prevent regression